### PR TITLE
Publicize setMethodCallHandler

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -7,6 +7,7 @@ export function createClient(options: {
 }): DBusClient;
 
 export interface DBusClient {
+    setMethodCallHandler: (objectPath: string, iface: string, member: string, handler: [(args: any[]) => void, any]) => void;
     getService(name: string): DBusService;
     disconnect(): Promise<void>;
 }


### PR DESCRIPTION
Add the `setMethodCallHandler` of `DBusClient` to the `types.d.ts` in order to call it from typescript apps.